### PR TITLE
Fix typo in german translation

### DIFF
--- a/www/languages/locale-de.json
+++ b/www/languages/locale-de.json
@@ -117,7 +117,7 @@
 	"missing_field": "Fehlendes Feld",
 	"error_saving_draft": "Fehler beim Senden des Entwurfs",
 	"success_saving_draft": "Entwurf gespeichert",
-	"success_updating_draft": "Entwurk aktualisiert",
+	"success_updating_draft": "Entwurf aktualisiert",
 	"view_details": "Details ansehen",
 	"password": "Passwort",
 	"create_account": "Konto einrichten",


### PR DESCRIPTION
Found a typo in german translations when saving a `draft`.

`Entwurk` was changed to `Entwurf`.